### PR TITLE
Enable parameterization of dataset transforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
     - PYTHON=3.5 NUMPY=1.11
     - PYTHON=2.7 NUMPY=1.11
 
+  allow_failures:
+    - PYTHON=2.7 NUMPY=1.11
+
 install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,3 @@ notifications:
   on_failure: always
   flowdock:
     secure: "qJfMEqTfEE7570pOcfoLzy4MsPBZ43igdR7zeQbOocH2UM5ort3GN1VakX4AnVbsNQREVz2i6lGlOFb7npQAV0Wgh6VTRrRYwuOdHL5P3YTR6p2voZr757BfAW3vaJCpsKLdDyTeFr/8qoD5GsKFzRPhJESrBnk57ll9YyhipYe1tg3RS/xt/EqO9V4bunCHeFYJ7UNEOx9ELDatOD8GeWmrLcgBuEM3B0EOrYr/rRNvjPTYPTq4MAq5k9mNbRWX/Y0KNGo0cPRXdXze5YCSfrhVUIxfDQ17lZeus8CmZsGqcRgmSFd0zV47zuU1uQp+A9DEVTPqVgcwPHBvjBc7YDXO74f6qMhFN2OaBFQcbHr/B64P4Qw0EOcWey2fa9/A7zoIWmMPx72ccJVdcpG761x2ZXM2e6MRcjgBvATPiKFxqwxmQvnGfJIn3hQaiRghbVdju6zK9sQlsDbrLSTvfbZD73httIg7UgKHyhPuErSpfV9TlwWbtnolKtVNlqs5GW/9d3tMZw4XWQCOmc3b3DPDY3Rje2JxW94qiNIleU6/Lo5SlU1sH/+cfB7+WkIQhDuWSdNPNlLU9kqHZTEmkSw5KYjcD5rDxy2Bcv+5mCpR8iUcR1LCvQHj/ov3zoBZgmsWwY2CU/mAddk4Ij609FawKSZ9MlX6Djh0ENJcI6c="
-
-deploy:
-  - provider: script
-    script:
-      - bash anaconda_upload.sh
-    on:
-      tags: false
-      all_branches: true
-    skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ env:
     - PYTHON=3.5 NUMPY=1.11
     - PYTHON=2.7 NUMPY=1.11
 
+matrix:
+  # Python 2.7 doesn't work yet, due to reliance on Python 3.6 features in the
+  # inspect stdlib
   allow_failures:
-    - PYTHON=2.7 NUMPY=1.11
+    - env: PYTHON=2.7 NUMPY=1.11
 
 install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ notifications:
 deploy:
   - provider: script
     script:
-      - conda install --name root anaconda-client && conda build $CHANNELS --output --python $PYTHON --numpy $NUMPY conda.recipe | sed 's/-py[^_]*/-py\*/' | xargs ls -1 | xargs conda convert -p all -o _pkgs && find _pkgs -type f -name "*.tar.bz2" -exec anaconda -t $ANACONDA_UPLOAD_TOKEN upload --user $ANACONDA_UPLOAD_USER --label dev {} \+
+      - bash anaconda_upload.sh
     on:
       tags: false
       all_branches: true

--- a/anaconda_upload.sh
+++ b/anaconda_upload.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+test -z "$ANACONDA_UPLOAD_USER" && echo "Please set the ANACONDA_UPLOAD_USER environment variable" && exit 1
+test -z "$ANACONDA_UPLOAD_TOKEN" && echo "Please set the ANACONDA_UPLOAD_TOKEN environment variable" && exit 1
+test -z "$CHANNELS" && echo "Please set the CHANNELS environment variable" && exit 1
+test -z "$PYTHON" && echo "Please set the PYTHON environment variable" && exit 1
+test -z "$NUMPY" && echo "Please set the NUMPY environment variable" && exit 1
+
+set -x
+
+conda install --name root anaconda-client
+pkg_fpath=~/miniconda/conda-bld/osx-64/xarray_filters-0.0.1-py36_18.tar.bz2 #`conda build $CHANNELS --output --python $PYTHON --numpy $NUMPY conda.recipe | sed 's/-py[^_]*/-py\*/' | xargs \ls -1`
+conda convert -p all -o _pkgs "$pkg_fpath"
+find _pkgs -type f -name "*.tar.bz2" -exec \
+     anaconda --token "$ANACONDA_UPLOAD_TOKEN" upload --user "$ANACONDA_UPLOAD_USER" --label dev {} \+

--- a/anaconda_upload.sh
+++ b/anaconda_upload.sh
@@ -11,7 +11,7 @@ test -z "$NUMPY" && echo "Please set the NUMPY environment variable" && exit 1
 set -x
 
 conda install --name root anaconda-client
-pkg_fpath=`conda build $CHANNELS --output --python $PYTHON --numpy $NUMPY conda.recipe | sed 's/-py[^_]*/-py\*/' | xargs \ls -1`
+pkg_fpath=`conda build $CHANNELS --output --python $PYTHON --numpy $NUMPY conda.recipe`
 conda convert -p all -o _pkgs "$pkg_fpath"
 find _pkgs -type f -name "*.tar.bz2" -exec \
      anaconda --token "$ANACONDA_UPLOAD_TOKEN" upload --user "$ANACONDA_UPLOAD_USER" --label dev {} \+

--- a/anaconda_upload.sh
+++ b/anaconda_upload.sh
@@ -11,7 +11,7 @@ test -z "$NUMPY" && echo "Please set the NUMPY environment variable" && exit 1
 set -x
 
 conda install --name root anaconda-client
-pkg_fpath=~/miniconda/conda-bld/osx-64/xarray_filters-0.0.1-py36_18.tar.bz2 #`conda build $CHANNELS --output --python $PYTHON --numpy $NUMPY conda.recipe | sed 's/-py[^_]*/-py\*/' | xargs \ls -1`
+pkg_fpath=`conda build $CHANNELS --output --python $PYTHON --numpy $NUMPY conda.recipe | sed 's/-py[^_]*/-py\*/' | xargs \ls -1`
 conda convert -p all -o _pkgs "$pkg_fpath"
 find _pkgs -type f -name "*.tar.bz2" -exec \
      anaconda --token "$ANACONDA_UPLOAD_TOKEN" upload --user "$ANACONDA_UPLOAD_USER" --label dev {} \+

--- a/anaconda_upload.sh
+++ b/anaconda_upload.sh
@@ -11,7 +11,7 @@ test -z "$NUMPY" && echo "Please set the NUMPY environment variable" && exit 1
 set -x
 
 conda install --name root anaconda-client
-pkg_fpath=`conda build $CHANNELS --output --python $PYTHON --numpy $NUMPY conda.recipe`
+pkg_fpath=`\ls -1 $HOME/miniconda/conda-bld/linux-64/xarray_filters-*.tar.bz2` # conda build --output does not work
 conda convert -p all -o _pkgs "$pkg_fpath"
 find _pkgs -type f -name "*.tar.bz2" -exec \
      anaconda --token "$ANACONDA_UPLOAD_TOKEN" upload --user "$ANACONDA_UPLOAD_USER" --label dev {} \+

--- a/notebooks/Parameterize-MLDataset.ipynb
+++ b/notebooks/Parameterize-MLDataset.ipynb
@@ -1,0 +1,397 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pipeline outside of ML\n",
+    "\n",
+    "This notebook shows some trial and error to create a `Pipeline` that can be used with `xarray_filters`.  \n",
+    "\n",
+    "This is a continuation of goals in [Elm issue #149](https://github.com/ContinuumIO/elm/issues/149) to separate ML from GIS utils."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The goal is to be able to run something like this:\n",
+    "```\n",
+    "from xarray_filters.pipeline import Pipeline\n",
+    "from xarary_filters.steps import Generic, Serialize\n",
+    "def step_1(dset, **kw):\n",
+    "    return kw['a'] * dset.mean(dim=('x', 'y')) ** kw['b']\n",
+    "\n",
+    "def step_2(dset, **kw):\n",
+    "    return kw['a'] + dset * kw['b']\n",
+    "    \n",
+    "steps = (('s1', Generic(step_1)),\n",
+    "         ('s2', Generic(step_2)),\n",
+    "         ('s3', Serialize('two_step_pipeline_out.nc')))\n",
+    "pipe = Pipeline(steps=steps)\n",
+    "pipe.set_params(s1__a=2,\n",
+    "                s1__b=3,\n",
+    "                s2__a=0,\n",
+    "                s2__b=0,\n",
+    "                s3__fname='file_with_zeros.nc')\n",
+    "pipe.fit_transform(X)\n",
+    "```\n",
+    " * The example above uses scikit-learn `set_params` style of setting parameters where:\n",
+    "   * Steps in the `Pipeline` are named, `s1`, `s2`, and `s3` in this case\n",
+    "   * Double underscore notation is used to pass parameters to the `set_params` method of a given step.  Here:\n",
+    "     * `a` and `b` are parameters accepted by `step_1` and `step_2`\n",
+    "     * `fname` is accepted by `Serialize`\n",
+    "   * The `Dataset` or `MLDataset` `X` is run through the 3 steps\n",
+    "   * Note the import statements with `xarray_filters` at top of snippet is what we need to do based on this notebook\n",
+    "* Classes formerly part of `elm.pipeline.steps` will now inherit from `sklearn.base.BaseEstimator`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from xarray_filters import MLDataset\n",
+    "from xarray_filters.tests.test_data import new_test_dataset\n",
+    "\n",
+    "from __future__ import absolute_import, division, print_function, unicode_literals\n",
+    "\n",
+    "import sklearn\n",
+    "from sklearn.pipeline import Pipeline as _Pipeline\n",
+    "\n",
+    "from abc import ABCMeta, abstractmethod\n",
+    "import six\n",
+    "\n",
+    "class Step(six.with_metaclass(ABCMeta,\n",
+    "                              sklearn.base.BaseEstimator,\n",
+    "                              sklearn.base.TransformerMixin)):\n",
+    "    \"\"\"Base class representing a schedulable / runnable unit of a Pipeline.\n",
+    "    \"\"\"\n",
+    "    def __init__(self, *args, **kwargs):\n",
+    "        args_copy = list(args)\n",
+    "        self.func = args_copy.pop()\n",
+    "        self.fit_transform = self.transform\n",
+    "        super(Step, self).__init__(*args_copy, **kwargs)\n",
+    "\n",
+    "    @abstractmethod\n",
+    "    def transform(self, X, y=None, **fit_params):\n",
+    "        \"\"\"Overridden by subclasses.\"\"\"\n",
+    "        return self.func(X, y, **fit_params)\n",
+    "\n",
+    "    \n",
+    "class Pipeline(_Pipeline):\n",
+    "    \"\"\"An abstraction for scheduling and running Step objects.\n",
+    "\n",
+    "    Reuses much of sklearn.base.Pipeline, but supports parallelizing Estimator\n",
+    "    objects with Dask.\n",
+    "    \"\"\"\n",
+    "    def __init__(self, steps, memory=None):\n",
+    "        \"\"\"Convert xarray_filters steps into sklearn steps, so we can reuse its Pipeline functionality.\"\"\"\n",
+    "        steps_copy = list(steps)\n",
+    "        if steps_copy[-1][1] is not None:\n",
+    "            steps_copy.append(('iden', None))\n",
+    "        super(Pipeline, self).__init__(steps_copy, memory)\n",
+    "\n",
+    "    def _transform(self, X):\n",
+    "        \"\"\"Here we can introduce dask-style computation / scheduling.\"\"\"\n",
+    "        Xt = X\n",
+    "        for name, step in self.steps:\n",
+    "            if step is not None:\n",
+    "                Xt = step.transform(Xt)\n",
+    "        return Xt\n",
+    "\n",
+    "    def _inverse_transform(self, X):\n",
+    "        \"\"\"Here we can introduce dask-style computation / scheduling.\"\"\"\n",
+    "        Xt = X\n",
+    "        for name, step in self.steps[::-1]:\n",
+    "            if step is not None:\n",
+    "                Xt = step.inverse_transform(Xt)\n",
+    "        return Xt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class Generic(Step):\n",
+    "    def __init__(self, func=None, a=None, b=None):\n",
+    "        self.a = a\n",
+    "        self.b = b\n",
+    "        super(Generic, self).__init__(func)\n",
+    "            \n",
+    "    def transform(self, dset, **kw):\n",
+    "        params = self.get_params()\n",
+    "        return self.func(dset=dset, **params)\n",
+    "\n",
+    "\n",
+    "class Serialize(Step):\n",
+    "    def __init__(self, fname, as_netcdf=True):\n",
+    "        self.fname = fname\n",
+    "        self.as_netcdf = as_netcdf\n",
+    "    \n",
+    "    def transform(self, dset, y=None):\n",
+    "        if self.as_netcdf:\n",
+    "            fname = self.get_params()['fname']\n",
+    "            dset.to_netcdf(fname)\n",
+    "            return dset\n",
+    "        else:\n",
+    "            pass # TODO other serializers?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<xarray.MLDataset>\n",
+       "Dimensions:      (t: 48, x: 20, y: 15, z: 8)\n",
+       "Coordinates:\n",
+       "  * x            (x) int64 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19\n",
+       "  * y            (y) int64 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14\n",
+       "  * z            (z) int64 0 1 2 3 4 5 6 7\n",
+       "  * t            (t) int64 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ...\n",
+       "Data variables:\n",
+       "    wind         (x, y, z, t) float64 0.4445 0.7416 0.6008 0.2171 0.7075 ...\n",
+       "    pressure     (x, y, z, t) float64 0.489 0.9108 0.7866 0.653 0.8514 ...\n",
+       "    temperature  (x, y, z, t) float64 0.1573 0.833 0.07375 0.8194 0.7863 ..."
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X = new_test_dataset(('wind', 'pressure', 'temperature',))\n",
+    "X"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def step_1(dset, **kw):\n",
+    "    return kw['a'] * dset.mean(dim=('x', 'y')) ** kw['b']\n",
+    "\n",
+    "def step_2(dset, **kw):\n",
+    "    return kw['a'] + dset * kw['b']\n",
+    "\n",
+    "steps = (('s1', Generic(step_1)),\n",
+    "         ('s2', Generic(step_2)),\n",
+    "         ('s3', Serialize('two_step_pipeline_out.nc')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "(_, s1), _, _ = steps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<xarray.DataArray 'temperature' (z: 8, t: 48)>\n",
+       "array([[ 0.423261,  0.413031,  0.528824, ...,  0.485638,  0.502162,  0.53497 ],\n",
+       "       [ 0.441905,  0.527673,  0.496324, ...,  0.547213,  0.517117,  0.529949],\n",
+       "       [ 0.529223,  0.537221,  0.493496, ...,  0.518275,  0.509642,  0.488531],\n",
+       "       ..., \n",
+       "       [ 0.495862,  0.525155,  0.475573, ...,  0.495561,  0.567319,  0.481611],\n",
+       "       [ 0.506853,  0.522342,  0.500386, ...,  0.491232,  0.515668,  0.498686],\n",
+       "       [ 0.495552,  0.568766,  0.487428, ...,  0.562324,  0.462024,  0.577248]])\n",
+       "Coordinates:\n",
+       "  * t        (t) int64 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 ...\n",
+       "  * z        (z) int64 0 1 2 3 4 5 6 7"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s1.set_params(a=0, b=0)\n",
+    "ones = s1.transform(X)\n",
+    "s1.set_params(a=2, b=2)\n",
+    "other = s1.transform(X)\n",
+    "other.temperature - ones.temperature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe = Pipeline(steps=steps)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Pipeline(memory=None,\n",
+       "     steps=[('s1', Generic(a=2, b=2, func=<function step_1 at 0x115d36ae8>)), ('s2', Generic(a=None, b=None, func=<function step_2 at 0x115d362f0>)), ('s3', Serialize(as_netcdf=True, fname='two_step_pipeline_out.nc')), ('iden', None)])"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pipe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<xarray.MLDataset>\n",
+       "Dimensions:      (t: 48, z: 8)\n",
+       "Coordinates:\n",
+       "  * t            (t) int64 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ...\n",
+       "  * z            (z) int64 0 1 2 3 4 5 6 7\n",
+       "Data variables:\n",
+       "    wind         (z, t) float64 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 ...\n",
+       "    pressure     (z, t) float64 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 ...\n",
+       "    temperature  (z, t) float64 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 ..."
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pipe.set_params(s1__a=2, s1__b=3, s2__a=0, s2__b=0, s3__fname='file_with_zeros.nc')\n",
+    "pipe.transform(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<xarray.MLDataset>\n",
+       "Dimensions:      (t: 48, z: 8)\n",
+       "Coordinates:\n",
+       "  * t            (t) int64 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ...\n",
+       "  * z            (z) int64 0 1 2 3 4 5 6 7\n",
+       "Data variables:\n",
+       "    wind         (z, t) float64 1.194 1.258 1.239 1.272 1.272 1.253 1.227 ...\n",
+       "    pressure     (z, t) float64 1.263 1.24 1.255 1.239 1.28 1.248 1.261 ...\n",
+       "    temperature  (z, t) float64 1.195 1.188 1.272 1.269 1.247 1.297 1.282 ..."
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pipe.set_params(s1__a=2, s1__b=3, s2__a=1, s2__b=1, s3__fname='file_nonzero.nc')\n",
+    "pipe.transform(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-rw-r--r--  1 gbrener  staff  18977 Sep 11 10:39 file_nonzero.nc\r\n",
+      "-rw-r--r--  1 gbrener  staff  18977 Sep 11 10:39 file_with_zeros.nc\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "! ls -l *.nc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Pipeline(memory=None,\n",
+       "     steps=[('s1', Generic(a=2, b=3, func=<function step_1 at 0x115d36ae8>)), ('s2', Generic(a=1, b=1, func=<function step_2 at 0x115d362f0>)), ('s3', Serialize(as_netcdf=True, fname='file_nonzero.nc')), ('iden', None)])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pipe"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/xarray_filters/pipeline.py
+++ b/xarray_filters/pipeline.py
@@ -1,0 +1,82 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import types
+from collections import OrderedDict
+
+import sklearn
+import sklearn.pipeline
+import six
+
+
+class PatchInitSig(type):
+    def __new__(cls, name, bases, attr):
+        # Create instance variables with the same names as class variables.
+        # The class variables serve as defaults, but the instance variables
+        # can be modified independently among instance objects.
+        setattr_section_strs = []
+        params_to_keep = []
+        for param, val in attr.items():
+            if not param.startswith('_') and param not in ('transform',):
+                setattr_section_strs.append('self.{0} = {0}'.format(param))
+                params_to_keep.append(param)
+        if not params_to_keep:
+            def init_method_noargs(self):
+                self.fit_transform = self.transform
+            attr['__init__'] = init_method_noargs
+        else:
+            init_method_str = '''def init_method_withargs(self, {}):
+    {}
+    self.fit_transform = self.transform
+'''.format(', '.join(['{}={}'.format(p, repr(attr[p])) for p in params_to_keep]),
+           '\n    '.join(setattr_section_strs))
+            #print(init_method_str)
+            exec(init_method_str) in globals(), locals()
+            attr['__init__'] = locals()['init_method_withargs']
+        return super(PatchInitSig, cls).__new__(cls, name, bases, attr)
+
+
+class Step(six.with_metaclass(PatchInitSig,
+                              sklearn.base.BaseEstimator,
+                              sklearn.base.TransformerMixin)):
+    """As an abstract base class, this should never be instantiated directly.
+    Instead, subclasses should be created which implement transform().
+    Additionally, __init__ should not be overridden.
+    """
+    def transform(self, X, y=None, **params):
+        """This method must be overridden by subclasses of Step."""
+
+
+class WriteNetCDF(Step):
+    fname = ''
+    def transform(self, dset):
+        params = self.get_params()
+
+        # Glean the fname from the parameters,
+        # defaulting to the constructor's default value.
+        fname = params.get('fname', self.fname)
+        del params['fname']
+
+        dset.to_netcdf(fname, **params)
+        return dset
+
+    
+class Pipeline(sklearn.pipeline.Pipeline):
+    def __init__(self, steps, memory=None):
+        steps_copy = list(steps)
+        if steps_copy[-1][1] is not None:
+            steps_copy.append(('iden', None))
+        super(Pipeline, self).__init__(steps_copy, memory)
+
+    def _transform(self, X):
+        Xt = X
+        for name, step in self.steps:
+            if step is not None:
+                Xt = step.transform(Xt)
+        return Xt
+
+    def _inverse_transform(self, X):
+        Xt = X
+        for name, step in self.steps[::-1]:
+            if step is not None:
+                Xt = step.inverse_transform(Xt)
+        return Xt

--- a/xarray_filters/tests/test_pipeline.py
+++ b/xarray_filters/tests/test_pipeline.py
@@ -1,0 +1,76 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from collections import OrderedDict
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xarray_filters.pipeline import Pipeline, Step, WriteNetCDF
+
+@pytest.fixture
+def ds_under_test():
+    from xarray_filters.tests.test_data import new_test_dataset
+    ds = new_test_dataset(('wind', 'pressure', 'temperature'))
+    return ds
+
+def test_set_params_fit_xform(ds_under_test):
+    def step_1(dset, **kw):
+        return kw['a'] * dset.mean(dim=('x', 'y')) ** kw['b']
+
+    def step_2(dset, **kw):
+        return kw['a'] + dset * kw['b']
+
+    class Generic(Step):
+        a = 0
+        b = 1
+        func = None
+        def transform(self, dset):
+            params = self.get_params()
+            dset = self.func(dset=dset, **params)
+            return dset
+
+    steps = (('s1', Generic(func=step_1)),
+             ('s2', Generic(func=step_2)),
+             ('s3', WriteNetCDF(fname='two_step_pipeline_out.nc')))
+    pipe = Pipeline(steps=steps)
+    ((_, pipe_step1), (_, pipe_step2), (_, pipe_step3)) = steps
+
+    assert pipe_step1.a == 0 and pipe_step1.b == 1 and pipe_step1.func is step_1
+    assert pipe_step2.a == 0 and pipe_step2.b == 1 and pipe_step2.func is step_2
+    assert pipe_step3.fname == 'two_step_pipeline_out.nc'
+
+    pipe.set_params(s1__a=2,
+                    s1__b=3,
+                    s2__a=0,
+                    s2__b=0,
+                    s3__fname='file_with_zeros.nc')
+
+    assert pipe_step1.a == 2 and pipe_step1.b == 3 and pipe_step1.func is step_1
+    assert pipe_step2.a == 0 and pipe_step2.b == 0 and pipe_step2.func is step_2
+    assert pipe_step3.fname == 'file_with_zeros.nc'
+
+    pipe.transform(ds_under_test)
+
+def test_estimator_cloning(ds_under_test):
+    from sklearn.base import clone
+
+    class Generic(Step):
+        a = 10
+        b = 12
+        func = None
+        lst = []
+        def transform(self, dset):
+            params = self.get_params()
+            dset = self.func(dset=dset, **params)
+            return dset
+
+    def step_1(dset, **kw):
+        return kw['a'] * dset.mean(dim=('x', 'y')) ** kw['b']
+
+    g_estimator = Generic(func=step_1, lst=[[1], 2, 3])
+    g_estimator_clone = clone(g_estimator)
+
+    assert g_estimator.a == g_estimator_clone.a
+    assert g_estimator.b == g_estimator_clone.b
+    assert g_estimator.func == g_estimator_clone.func


### PR DESCRIPTION
Add `Pipeline` and `Steps` class, addressing issue #10 and enabling parametrization of MLDataset/xr.Dataset objects. The following is an example of the API (subject to change, of course):

Example: Defining a transformer which has `a` and `b` as settable/gettable parameters, as well as an arbitrary function:
```
from xarray_filters.pipeline import Step

class Generic(Step):
    a = 123
    b = 10
    func = None
    def transform(self, dset):
        return self.func(dset, **self.get_params())

def step_1(dset, **kw):
    return kw['a'] + dset * kw['b']

step1 = Generic(func=step_1)
```
Note that in order for this to be compatible with the `sklearn` Estimators API, the keyword arguments had to be explicitly declared to the `__init__` method. This implementation detail is hidden from the API by requiring users to declare the default values as assignments to class variables (shown above). The API will hopefully be familiar to those who have used Django.

Here is a continuation of the example above, with a `Pipeline`:
```
from xarray_filters.pipeline import Pipeline, WriteNetCDF

# WriteNetCDF is a built-in estimator derived from Step (just like Generic)
pipe = Pipeline(('s1', step1), ('s2', WriteNetCDF(fname='pipe_out.nc'))
pipe.transform()
```

In the last example, we can use `<estimator>.set_params()` and `<estimator>.get_params()`, as well as using the `sklearn.base.clone(<estimator>)` function, where `<estimator>` can be either `pipe`, `step1`, or the instance of `WriteNetCDF`.