### PR TITLE
Testing tools

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,27 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+[html]
+directory = coverage_html_report
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# xarray_filters: [TODO: one-line description]
+
+[TODO: description]
+
+# Testing
+
+Testing the codebase under your active conda environment can be done simply by
+running `pytest` at the top level directory.
+
+If you want to run the test suite for _all_ the environments we need to
+support, run the script `run_tests.py`.
+
+If you want to create more environments to be tested with `run_tests.py`, just
+create another conda environment spec file that matches the pattern
+`environment*.yml`.
+

--- a/environment_py27.yml
+++ b/environment_py27.yml
@@ -1,0 +1,12 @@
+name: xarray_filters_py27
+channels:
+ - conda-forge # essential for rasterio on osx
+dependencies:
+ - python=2.7
+ - funcsigs
+ - numpy
+ - pandas
+ - pytest
+ - pytest-cov
+ - scikit-learn
+ - xarray

--- a/environment_py27.yml
+++ b/environment_py27.yml
@@ -10,3 +10,4 @@ dependencies:
  - pytest-cov
  - scikit-learn
  - xarray
+ - six

--- a/environment_py35.yml
+++ b/environment_py35.yml
@@ -9,3 +9,4 @@ dependencies:
  - pytest-cov
  - scikit-learn
  - xarray
+ - six

--- a/environment_py35.yml
+++ b/environment_py35.yml
@@ -1,0 +1,11 @@
+name: xarray_filters_py35
+channels:
+ - conda-forge # essential for rasterio on osx
+dependencies:
+ - python=3.5
+ - numpy
+ - pandas
+ - pytest
+ - pytest-cov
+ - scikit-learn
+ - xarray

--- a/environment_py36.yml
+++ b/environment_py36.yml
@@ -9,3 +9,4 @@ dependencies:
  - pytest-cov
  - scikit-learn
  - xarray
+ - six

--- a/environment_py36.yml
+++ b/environment_py36.yml
@@ -1,0 +1,11 @@
+name: xarray_filters_py36
+channels:
+ - conda-forge # essential for rasterio on osx
+dependencies:
+ - python=3.6
+ - numpy
+ - pandas
+ - pytest
+ - pytest-cov
+ - scikit-learn
+ - xarray

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --doctest-modules
+doctest_optionflags= IGNORE_EXCEPTION_DETAIL ELLIPSIS
+testpaths = xarray_filters

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,88 @@
+import yaml
+import glob
+import subprocess
+import sys
+import time
+import datetime
+import shlex
+
+assert sys.version_info >= (3,)
+
+# Run one test per conda env file
+
+def utc_timestamp():
+    return datetime.datetime.timestamp(datetime.datetime.utcnow())
+
+def exists_env(env_name):
+    """Check if the environment name from env_fpath exists."""
+    cmd = 'conda env list'
+    out = subprocess.check_output(cmd, shell=True)
+    out_lines = out.decode('utf-8').splitlines()
+    env_names = [l.split()[0] for l in out_lines if l]
+    env_exists = env_name in env_names
+    return env_exists
+
+def create_env(env_fpath):
+    """Make conda env create command based on environment*.yml file"""
+    cmd = 'conda env create -f {}'.format(env_fpath)
+    out = subprocess.check_output(cmd, shell=True)
+    return out
+
+def run_tests(env_name):
+    """Run tests in the conda env of env_fpath."""
+    test_cmd = 'pytest --cov'
+    cmd = 'source activate {} && {} && source deactivate'.format(env_name, test_cmd)
+    with subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
+        out = proc.stdout.read()
+    return out.decode(encoding='utf-8')
+
+def make_test_report(env_name):
+    cmd_output = lambda cmd: subprocess.check_output(shlex.split(cmd)).decode('utf-8').rstrip()
+    test_report = {
+        'git_commit': cmd_output('git rev-parse HEAD'),
+        'git_diff': cmd_output('git diff'),
+        'git_remotes': cmd_output('git remote -v'),
+        'git_user.name': cmd_output('git config user.name'),
+        'git_user.email': cmd_output('git config user.email'),
+        'conda_env_spec.yaml': cmd_output('conda env export -n ' + env_name)
+    }
+    test_report['t0_UTC'] = utc_timestamp()
+    test_report['test_report'] = run_tests(env_name)
+    test_report['t1_UTC'] = utc_timestamp()
+    test_report['test_status'] = [l.rstrip()
+            for l in test_report['test_report'].splitlines()
+            if (l.startswith('=============') and 'seconds' in l)][-1]
+    return test_report
+
+if __name__ == "__main__":
+    import os
+    import json
+
+    test_logs_dir = 'test_logs'
+    try:
+        os.mkdir(test_logs_dir)
+    except FileExistsError:
+        pass
+
+    env_files = glob.glob('environment*.yml') + glob.glob('environment*.yaml')
+    ntests = len(env_files)
+    for (testn, env_fpath) in enumerate(env_files):
+        with open(env_fpath) as f:
+            env_data = yaml.load(f)
+        print("Running tests for environment {:d} out of {:d}: {}".format(
+            testn + 1, ntests, env_data['name']))
+        if not exists_env(env_data['name']):
+            create_env(enf_fpath)
+        test_report = make_test_report(env_data['name'])
+        timestamp_suffix = datetime.datetime.fromtimestamp(test_report['t0_UTC']).strftime('%Y%m%d_%H%M%S')
+        test_log_fname = env_data['name'] + '_test-' + timestamp_suffix + '.json'
+        report_path = os.path.join(test_logs_dir, test_log_fname)
+        with open(report_path, mode='a') as f:
+            json.dump(test_report, f, indent=4)
+        print('Test log in {}'.format(report_path))
+        print(test_report['test_status'] + '\n')
+
+    print("All tests finished. Run\n")
+    print("    echo -e $(jq '.test_report' <logfile_path>)")
+    print("\nto see the test report. Additional metadata stored in the log file json.")
+


### PR DESCRIPTION
This PR is ready for review.

It adds some the following:

- `environment_py{27,35,36}`.yml: conda env specs for each environment we want to support.
- `run_tests.py`: to run the test suite for each conda env that matches `environment*.yml`.
- `pytest.ini`: pytest configurations
- `.coveragerc`: minimal coverage configurations
- `README.md`: includes testing instructions.

Feel free to change things, but this works as is for me.

After you run `run_tests.py`, you should some messages, like this:

```bash
0269-gpfreitas:xarray_filters gpfreitas$ python run_tests.py
Running tests for environment 1 out of 3: xarray_filters_py27
Test log in test_logs/xarray_filters_py27_test-20170915_203829.json
=========================== 23 error in 8.47 seconds ===========================

Running tests for environment 2 out of 3: xarray_filters_py35
Test log in test_logs/xarray_filters_py35_test-20170915_203843.json
========================== 17 passed in 2.51 seconds ===========================

Running tests for environment 3 out of 3: xarray_filters_py36
Test log in test_logs/xarray_filters_py36_test-20170915_203852.json
========================== 17 passed in 2.15 seconds ===========================

All tests finished. Run

    echo -e $(jq '.test_report' <logfile_path>)

to see the test report. Additional metadata stored in the log file json.
```

As the message above says, test logs (JSON format) are stored inside a `test_logs` directory.

```bash
0269-gpfreitas:xarray_filters gpfreitas$ ls -lrt test_logs/
total 176
-rw-r--r--  1 gpfreitas  staff  17006 Sep 15 15:05 xarray_filters_py27_test-20170915_200544.json
-rw-r--r--  1 gpfreitas  staff   8902 Sep 15 15:05 xarray_filters_py35_test-20170915_200551.json
-rw-r--r--  1 gpfreitas  staff   8902 Sep 15 15:06 xarray_filters_py36_test-20170915_200559.json
-rw-r--r--  1 gpfreitas  staff  17071 Sep 15 15:07 xarray_filters_py27_test-20170915_200735.json
-rw-r--r--  1 gpfreitas  staff   8967 Sep 15 15:07 xarray_filters_py35_test-20170915_200742.json
-rw-r--r--  1 gpfreitas  staff   8967 Sep 15 15:07 xarray_filters_py36_test-20170915_200750.json
```

As you can see the JSON files include a simple timestamp (in UTC) in the name, as well as the name of the environment.

Each log file reports:

- `conda_env_spec.yaml`: a multiline string with the output of `conda env export -n <env_name>`
- `git_commit`: the git commit
- `git_diff`: the output of `git diff` at the working tree; you can use this plus the commit to reconstruct the codebase used in the test.
- `git_remotes`: list of git remotes (notably origin)
- `git_user.email`: email of user that ran the tests
- `git_user.name`: name of user that ran the tests
- `t0_UTC`: start of test timestamp
- `t1_UTC`: end of test timestamp
- `test_report`: a multiline string with the output of pytest
- `test_status`: the status line that pytest reports at the end summarizing how many tests passed, failed, etc.