### PR TITLE
Get the tests passing for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ env:
     - PYTHON=3.5 NUMPY=1.11
     - PYTHON=2.7 NUMPY=1.11
 
-matrix:
-  # Python 2.7 doesn't work yet, due to reliance on Python 3.6 features in the
-  # inspect stdlib
-  allow_failures:
-    - env: PYTHON=2.7 NUMPY=1.11
-
 install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda

--- a/environment_py27.yml
+++ b/environment_py27.yml
@@ -13,3 +13,6 @@ dependencies:
  - scikit-learn
  - xarray
  - six
+ - attrs
+ - conda-forge::rasterio
+ - conda-forge::gdal=2.1.*

--- a/environment_py35.yml
+++ b/environment_py35.yml
@@ -12,3 +12,7 @@ dependencies:
  - scikit-learn
  - xarray
  - six
+ - attrs
+ - conda-forge::rasterio
+ - conda-forge::gdal=2.1.*
+

--- a/environment_py36.yml
+++ b/environment_py36.yml
@@ -12,3 +12,7 @@ dependencies:
  - scikit-learn
  - xarray
  - six
+ - attrs
+ - conda-forge::rasterio
+ - conda-forge::gdal=2.1.*
+

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(name='xarray_filters',
       description='Readers',
       include_package_data=True,
       install_requires=[],
-      packages=['xarray_filters'],
+      packages=['xarray_filters', 'xarray_filters.tests'],
       package_data={},
       entry_points={})

--- a/xarray_filters/datasets.py
+++ b/xarray_filters/datasets.py
@@ -124,7 +124,7 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-class NpXyTransformer:
+class NpXyTransformer(object):
     "Transforms a pair (feature_matrix, labels_vector) with to_* methods."
     # Transform methods are to_f where f in accepted types
     accepted_types = ('array', 'dataframe', 'dataset', 'mldataset')
@@ -380,6 +380,7 @@ def _make_base(skl_sampler_func):
         assert not skl_argspec.varargs, "{} has variable positional arguments".format(skl_sampler_func.__name__)
         assert len(skl_argspec.args) == len(skl_argspec.defaults), \
                 "Some args of {} have no default value".format(skl_sampler_func.__name__)
+
     default_astype = 'mldataset'
     def wrapper(*args, **kwargs):
         '''

--- a/xarray_filters/datasets.py
+++ b/xarray_filters/datasets.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 """
 Overview
 --------
@@ -99,7 +101,6 @@ the keyword `astype`) is
 
 
 """
-
 
 
 import inspect

--- a/xarray_filters/func_signatures.py
+++ b/xarray_filters/func_signatures.py
@@ -3,12 +3,6 @@
 
 ``elm.config.func_signatures``
 
-TODO - this file currently still exists in `xarray_filters`
-but had modifications in xarray_filters PR 3.  Look at
-the the diff between xarray_filters's and this one and see
-how changes here in PR 3 affect usages elsewhere in
-elm / xarray_filters.
-
 TODO: add doctests - confirm docstrings adequate
 
 TODO: check Py 2 and 3 compat - see commented code

--- a/xarray_filters/pipeline.py
+++ b/xarray_filters/pipeline.py
@@ -16,7 +16,9 @@ class PatchInitSig(type):
         setattr_section_strs = []
         params_to_keep = []
         for param, val in attr.items():
-            if param not in ('transform','fit', 'fit_transform', 'score', 'predict'):
+            if callable(val) or isinstance(val, classmethod):
+                continue
+            if param not in ('transform', 'fit', 'fit_transform', 'score', 'predict'):
                 if not param.startswith('_'):
                     setattr_section_strs.append('self.{0} = {0}'.format(param))
                     params_to_keep.append(param)
@@ -30,7 +32,8 @@ class PatchInitSig(type):
     self.fit_transform = self.transform
 '''.format(', '.join(['{}={}'.format(p, repr(attr[p])) for p in params_to_keep]),
            '\n    '.join(setattr_section_strs))
-            #print(init_method_str)
+            # print('@@@', name)
+            # print('@@@', init_method_str)
             exec(init_method_str) in globals(), locals()
             attr['__init__'] = locals()['init_method_withargs']
         return super(PatchInitSig, cls).__new__(cls, name, bases, attr)

--- a/xarray_filters/tests/test_datasets.py
+++ b/xarray_filters/tests/test_datasets.py
@@ -1,1 +1,3 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 

--- a/xarray_filters/ts_grid_tools.py
+++ b/xarray_filters/ts_grid_tools.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import describe as scipy_describe
 import xarray as xr
+import six
 
 from xarray_filters.constants import (FEATURES_LAYER_DIMS,
                                       FEATURES_LAYER,
@@ -41,7 +42,7 @@ def _validate_dims_axis(axis, dim, dims, shape):
 def _validate_layer(dset, layer):
     if layer is None:
         layer = tuple(dset.data_vars)
-    elif isinstance(layer, str):
+    elif isinstance(layer, six.string_types):
         layer = (layer,)
     return layer
 

--- a/xarray_filters/utils.py
+++ b/xarray_filters/utils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import OrderedDict, defaultdict
 from xarray.core.indexing import PandasIndexAdapter
 from xarray.core.variable import as_variable
+import six
 
 
 def is_dict_like(value):
@@ -55,7 +56,7 @@ def _infer_coords_and_dims(shape, coords, dims):
                          'which does not match the %s dimensions of the '
                          'data' % (len(coords), len(shape)))
 
-    if isinstance(dims, str):
+    if isinstance(dims, six.string_types):
         dims = (dims,)
 
     if dims is None:
@@ -73,7 +74,7 @@ def _infer_coords_and_dims(shape, coords, dims):
         dims = tuple(dims)
     else:
         for d in dims:
-            if not isinstance(d, str):
+            if not isinstance(d, six.string_types):
                 raise TypeError('dimension %s is not a string' % d)
 
     new_coords = OrderedDict()

--- a/xarray_filters/utils.py
+++ b/xarray_filters/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from collections import OrderedDict, defaultdict
 from xarray.core.indexing import PandasIndexAdapter
 from xarray.core.variable import as_variable


### PR DESCRIPTION
This PR addresses #12. Merge-ability will be based on the tests passing for all currently-supported Python versions, including Python 2.7.