### PR TITLE
rename to_array -> to_xy_arrays - fix dataset/numpy transitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ dist: trusty
 env:
   global:
     - CHANNELS=" -c conda-forge "
+    - ANACONDA_UPLOAD_USER=elm
+    - CHANNELS=" -c conda-forge"
 
   matrix:
     - PYTHON=3.6 NUMPY=1.12
@@ -32,3 +34,4 @@ notifications:
   on_failure: always
   flowdock:
     secure: "qJfMEqTfEE7570pOcfoLzy4MsPBZ43igdR7zeQbOocH2UM5ort3GN1VakX4AnVbsNQREVz2i6lGlOFb7npQAV0Wgh6VTRrRYwuOdHL5P3YTR6p2voZr757BfAW3vaJCpsKLdDyTeFr/8qoD5GsKFzRPhJESrBnk57ll9YyhipYe1tg3RS/xt/EqO9V4bunCHeFYJ7UNEOx9ELDatOD8GeWmrLcgBuEM3B0EOrYr/rRNvjPTYPTq4MAq5k9mNbRWX/Y0KNGo0cPRXdXze5YCSfrhVUIxfDQ17lZeus8CmZsGqcRgmSFd0zV47zuU1uQp+A9DEVTPqVgcwPHBvjBc7YDXO74f6qMhFN2OaBFQcbHr/B64P4Qw0EOcWey2fa9/A7zoIWmMPx72ccJVdcpG761x2ZXM2e6MRcjgBvATPiKFxqwxmQvnGfJIn3hQaiRghbVdju6zK9sQlsDbrLSTvfbZD73httIg7UgKHyhPuErSpfV9TlwWbtnolKtVNlqs5GW/9d3tMZw4XWQCOmc3b3DPDY3Rje2JxW94qiNIleU6/Lo5SlU1sH/+cfB7+WkIQhDuWSdNPNlLU9kqHZTEmkSw5KYjcD5rDxy2Bcv+5mCpR8iUcR1LCvQHj/ov3zoBZgmsWwY2CU/mAddk4Ij609FawKSZ9MlX6Djh0ENJcI6c="
+  script: source ./anaconda_upload.sh

--- a/notebooks/20170905_Nasa_meeting_demo_xarray_filters.ipynb
+++ b/notebooks/20170905_Nasa_meeting_demo_xarray_filters.ipynb
@@ -287,7 +287,7 @@
                 "\n",
                 "The central functionality here is implemented in the following two objects:\n",
                 "\n",
-                "- The `NpXyTransformer` class that has multiple `to_*` methods (`to_dataset`, `to_dataframe`, `to_array`, etc.). Adding different postprocessing routines can be done by adding a new `NpXyTransformer.to_*` method with the appropriate code and documentation.\n",
+                "- The `NpXyTransformer` class that has multiple `to_*` methods (`to_dataset`, `to_dataframe`, `to_xy_arrays`, etc.). Adding different postprocessing routines can be done by adding a new `NpXyTransformer.to_*` method with the appropriate code and documentation.\n",
                 "- A `_make_base` function that takes as input a `sklearn.datasets._make_*` function (like `make_classification`) and creates a new \"version\" of it under the `datasets` namespace, with useful signature, docs and extended functionality.\n",
                 "\n",
                 "It's easier to see with an example. Let's construct the same data with the \"direct\" approach (using the keyword `astype` inside the `make_*` function) and the step-by-step approach (which is what the direct approach does under the hood)."
@@ -311,7 +311,7 @@
             "source": [
                 "Xyt = ds.make_classification(n_samples=20, n_features=4, n_classes=2, random_state=0,  # sklearn args\n",
                 "                             astype=None)\n",
-                "X2, y2 = Xyt.to_array()"
+                "X2, y2 = Xyt.to_xy_arrays()"
             ]
         },
         {
@@ -357,7 +357,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "help(ds.NpXyTransformer.to_array)"
+                "help(ds.NpXyTransformer.to_xy_arrays)"
             ]
         },
         {
@@ -385,7 +385,7 @@
             "source": [
                 "my_classification = ds._make_base(skd.make_classification)\n",
                 "Xyt = my_classification(n_samples=20, n_features=4, n_classes=2, random_state=0, astype=None)\n",
-                "X, y = Xyt.to_array()\n",
+                "X, y = Xyt.to_xy_arrays()\n",
                 "X, y\n",
                 "\n",
                 "# same as\n",

--- a/notebooks/Parameterize-MLDataset.ipynb
+++ b/notebooks/Parameterize-MLDataset.ipynb
@@ -247,7 +247,7 @@
    },
    "outputs": [],
    "source": [
-    "Xa, ya = X.to_array()"
+    "Xa, ya = X.to_xy_arrays()"
    ]
   },
   {

--- a/xarray_filters/datasets.py
+++ b/xarray_filters/datasets.py
@@ -58,7 +58,7 @@ For example, to obtain the exact same behavior as in sklearn, you can pass
 `astype='array'`:
 
 To support all the conversions, we create a class `NpXyTransformer` that has one
-method (`to_array`, `to_dataset`, `to_dataframe`, etc.) per conversion. In
+method (`to_xy_arrays`, `to_dataset`, `to_dataframe`, etc.) per conversion. In
 addition, we implement a `_make_base` function that maps a
 `sklearn.datasets.make_*` function to the new, extended version with a useful
 docstring. On Python 3 that new function also has an appropriate/helpful
@@ -137,7 +137,7 @@ class NpXyTransformer(object):
         self.X = X  # always a 2d numpy.array
         self.y = y  # always a 1d numpy.array
 
-    def to_array(self, xshape=None):
+    def to_xy_arrays(self, xshape=None):
         """Return X, y NumPy arrays with given shape
 
         Parameters
@@ -158,10 +158,10 @@ class NpXyTransformer(object):
         --------
         >>> transformer = make_blobs(n_samples=4, n_features=3, random_state=0,
         ...     astype=None, chunks=2)
-        >>> X, y = transformer.to_array()
+        >>> X, y = transformer.to_xy_arrays()
         >>> X.shape
         (4, 3)
-        >>> X, y = transformer.to_array(xshape=(12, 1))
+        >>> X, y = transformer.to_xy_arrays(xshape=(12, 1))
         >>> X.shape
         (12, 1)
         """
@@ -312,7 +312,7 @@ class NpXyTransformer(object):
         --------
 
         NpXyTransformer.to_dataset
-        NpXyTransformer.to_array
+        NpXyTransformer.to_xy_arrays
         NpXyTransformer.to_dataframe
         NpXyTransformer.to_*
         etc...

--- a/xarray_filters/reshape.py
+++ b/xarray_filters/reshape.py
@@ -22,7 +22,8 @@ from xarray_filters.pipe_utils import for_each_array
 __all__ = ['has_features',
            'concat_ml_features',
            'from_features',
-           'to_features',]
+           'to_features',
+           'to_xy_arrays']
 
 
 def has_features(dset, raise_err=True, features_layer=None):
@@ -276,7 +277,10 @@ def to_xy_arrays(dset=None, y=None, features_layer=None,
         return dset, y
     if not isinstance(dset, (xr.Dataset, MLDataset)):
         return dset, y
-    dset = dset.to_features(features_layer=features_layer)
+    if dset is None:
+        y, _ = to_xy_arrays(dset=y, **orig_kw)
+        return None, y
+    dset = to_features(dset, features_layer=features_layer)
     arr = dset[features_layer or FEATURES_LAYER]
     col_dim = arr.dims[1]
     col_labels = getattr(arr, col_dim)

--- a/xarray_filters/tests/test_reshape.py
+++ b/xarray_filters/tests/test_reshape.py
@@ -142,7 +142,7 @@ def test_from_features_dropped_rows(X):
 
     # Assert that we get the original Dataset back after X.to_features().from_features()
     assert np.array_equal(data1.coords.to_index().values, X.coords.to_index().values)
-    assert np.allclose(data1.to_array()[0], X.to_array()[0])
+    assert np.allclose(data1.to_xy_arrays()[0], X.to_xy_arrays()[0])
 
     # Drop some rows
     features['features'].values[:2, :] = np.nan
@@ -153,6 +153,6 @@ def test_from_features_dropped_rows(X):
     data2 = features.from_features()
 
     # Assert that the coords are correct, and NaNs are in the right places
-    if np.nan in data2.to_array()[0]:
+    if np.nan in data2.to_xy_arrays()[0]:
         assert np.array_equal(data2.coords.to_index().values, data1.coords.to_index().values)
-        assert np.allclose(data2.to_array()[0], zerod_vals_copy, equal_nan=True)
+        assert np.allclose(data2.to_xy_arrays()[0], zerod_vals_copy, equal_nan=True)


### PR DESCRIPTION
* [x] Fixes #38 
* [x] Also makes changes to a function that was `MLDataset.to_array`.  That was not the best name for the function because it returns an `X,y` tuple.  Now the function is `xarray_filters.reshape.to_xy_arrays` and it can be called as a standalone function or a `MLDataset` method.

TODO:
 * [ ] Add unit tests of `to_xy_arrays` that check a number of different possible data types for `X` and `y` (see data structures list here - https://github.com/ContinuumIO/elm/issues/202)